### PR TITLE
Add google_checks.xml control for checkstyle dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,17 @@ apply plugin: 'checkstyle'
 sourceCompatibility = 1.6
 println 'Source Compatibility:' + sourceCompatibility
 
+def versions = [
+        checkstyle: '7.1',
+        junit: '4.12'
+]
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: "${versions.junit}"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -25,12 +30,22 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-checkstyle {
-    toolVersion = '7.0'
-}
-
 artifacts {
     archives sourcesJar
     archives javadocJar
+}
+
+configurations {
+    checkstyleConfig
+}
+
+dependencies {
+    checkstyleConfig ("com.puppycrawl.tools:checkstyle:${versions.checkstyle}") {
+        transitive = false
+    }
+}
+checkstyle {
+    toolVersion = "${versions.checkstyle}"
+    config = resources.text.fromArchiveEntry(configurations.checkstyleConfig, 'google_checks.xml')
 }
 


### PR DESCRIPTION
Following information reflected here:
https://docs.gradle.org/2.2/release-notes?_ga=1.80854739.575576443.1471479861#sharing-configuration-files-across-builds